### PR TITLE
Add instructions to install packages to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Repository for distributing (some) stan-dev R packages
 
-A place for publishing new versions of (some) `stan-dev` R packages before they reach CRAN and for `stan-dev` R packages and versions where releasing on CRAN is not a (current) goal.
+A place for publishing new versions of (some) `stan-dev` R packages before they reach CRAN and for `stan-dev` R packages and versions where releasing on CRAN is not a (current) goal. As of 2021-03-16 this is most relevant for `rstan`, where the CRAN version is unfortunately several releases behind and pushing a new version to CRAN has been difficult.
 
-**Instructions for publishing or updating on this repository**
+To install latest `rstan` or other packages from the repo, add `https://mc-stan.org/r-packages/` to your repository list, e.g.:
+
+```r
+install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+```
+
+## How to publish/update packages on this repository
 
 **For stan-dev/r-packages maintainers**
 


### PR DESCRIPTION
I wanted to point some users to the package repo and it appears we don't have a good place that would just say "this is how you install packages from this repo". So I thought this should be added to the readme, so that https://mc-stan.org/r-packages/ is more comprehensible to non-devs and can serve as an URL we can actually share with users.